### PR TITLE
fix: gstreamer delay hot fix

### DIFF
--- a/gstreamer.orogen
+++ b/gstreamer.orogen
@@ -74,6 +74,12 @@ task_context "WebRTCCommonTask", subclasses: "Common" do
     # Configuration of the signalling process
     property "signalling", "/gstreamer/SignallingConfig"
 
+    # The GStreamer object latency
+    property "latency", "base/Time"
+
+    # If the Gstreamer object drops on latency
+    property "m_drop_on_latency", "bool"
+
     # Reception of WebRTC signalling messages
     input_port("signalling_in", "/webrtc_base/SignallingMessage")
         .needs_reliable_connection

--- a/gstreamer.orogen
+++ b/gstreamer.orogen
@@ -78,7 +78,7 @@ task_context "WebRTCCommonTask", subclasses: "Common" do
     property "latency", "base/Time"
 
     # If the Gstreamer object drops on latency
-    property "drop_on_latency", "bool"
+    property "drop_on_latency", "bool", true
 
     # Reception of WebRTC signalling messages
     input_port("signalling_in", "/webrtc_base/SignallingMessage")

--- a/gstreamer.orogen
+++ b/gstreamer.orogen
@@ -78,7 +78,7 @@ task_context "WebRTCCommonTask", subclasses: "Common" do
     property "latency", "base/Time"
 
     # If the Gstreamer object drops on latency
-    property "m_drop_on_latency", "bool"
+    property "drop_on_latency", "bool"
 
     # Reception of WebRTC signalling messages
     input_port("signalling_in", "/webrtc_base/SignallingMessage")

--- a/tasks/WebRTCCommonTask.cpp
+++ b/tasks/WebRTCCommonTask.cpp
@@ -551,7 +551,7 @@ WebRTCCommonTask::Peer& WebRTCCommonTask::configureWebRTCBin(string const& peer_
     peer.last_signalling_message = base::Time::now();
 
     g_object_set(webrtcbin, "bundle-policy", m_signalling_config.bundle_policy, nullptr);
-    g_object_set(webrtcbin, "latency", m_latency, NULL);
+    g_object_set(webrtcbin, "latency", m_latency.toMilliseconds(), NULL);
 
     GstElement* rtpbin = gst_bin_get_by_name(GST_BIN(webrtcbin), "rtpbin");
     g_object_set(rtpbin, "drop-on-latency", m_drop_on_latency, NULL);

--- a/tasks/WebRTCCommonTask.cpp
+++ b/tasks/WebRTCCommonTask.cpp
@@ -26,6 +26,8 @@ bool WebRTCCommonTask::configureHook()
         return false;
 
     m_signalling_config = _signalling.get();
+    m_latency = _latency.get();
+    m_drop_on_latency = _drop_on_latency.get();
     configureDataChannels();
     return true;
 }
@@ -549,10 +551,11 @@ WebRTCCommonTask::Peer& WebRTCCommonTask::configureWebRTCBin(string const& peer_
     peer.last_signalling_message = base::Time::now();
 
     g_object_set(webrtcbin, "bundle-policy", m_signalling_config.bundle_policy, nullptr);
-    g_object_set(webrtcbin, "latency", 50, NULL);
+    g_object_set(webrtcbin, "latency", m_latency, NULL);
 
     GstElement* rtpbin = gst_bin_get_by_name(GST_BIN(webrtcbin), "rtpbin");
-    g_object_set(rtpbin, "drop-on-latency", true, NULL);
+    g_object_set(rtpbin, "drop-on-latency", m_drop_on_latency, NULL);
+
     gst_object_unref(rtpbin);
 
     g_signal_connect(webrtcbin,

--- a/tasks/WebRTCCommonTask.cpp
+++ b/tasks/WebRTCCommonTask.cpp
@@ -549,6 +549,11 @@ WebRTCCommonTask::Peer& WebRTCCommonTask::configureWebRTCBin(string const& peer_
     peer.last_signalling_message = base::Time::now();
 
     g_object_set(webrtcbin, "bundle-policy", m_signalling_config.bundle_policy, nullptr);
+    g_object_set(webrtcbin, "latency", 50, NULL);
+
+    GstElement* rtpbin = gst_bin_get_by_name(GST_BIN(webrtcbin), "rtpbin");
+    g_object_set(rtpbin, "drop-on-latency", true, NULL);
+    gst_object_unref(rtpbin);
 
     g_signal_connect(webrtcbin,
         "notify::signaling-state",

--- a/tasks/WebRTCCommonTask.hpp
+++ b/tasks/WebRTCCommonTask.hpp
@@ -43,6 +43,8 @@ namespace gstreamer {
         };
 
         base::Time m_last_offer_request;
+        base::Time m_latency;
+        bool m_drop_on_latency;
 
         typedef std::map<GstElement*, Peer> PeerMap;
         PeerMap m_peers;

--- a/tasks/WebRTCCommonTask.hpp
+++ b/tasks/WebRTCCommonTask.hpp
@@ -45,7 +45,6 @@ namespace gstreamer {
         base::Time m_last_offer_request;
         base::Time m_latency;
         bool m_drop_on_latency;
-
         typedef std::map<GstElement*, Peer> PeerMap;
         PeerMap m_peers;
         PeerMap::const_iterator findPeerByID(std::string const& peer_id) const;

--- a/tasks/WebRTCReceiveTask.cpp
+++ b/tasks/WebRTCReceiveTask.cpp
@@ -167,8 +167,6 @@ void WebRTCReceiveTask::handleVideoStream(GstElement* bin, GstPad* pad)
     GstElement* q = gst_element_factory_make("queue", NULL);
     GstElement* conv = gst_element_factory_make("videoconvert", NULL);
     GstElement* sink = gst_element_factory_make("appsink", "video_out");
-    // The max buffers is set to 1, so it gets the first value and send
-    // it directly, so it disables the buffer behavior
     g_object_set(sink, "max-buffers", 1, NULL);
     g_object_set(sink, "drop", true, NULL);
 
@@ -224,6 +222,7 @@ void WebRTCReceiveTask::onIncomingStream(GstElement* webrtcbin, GstPad* pad)
     gst_bin_add(GST_BIN(m_pipeline), bin);
 
     GstElement* decodebin = gst_element_factory_make("decodebin", NULL);
+    g_object_set(decodebin, "max-size-buffers", 1, NULL);
     g_signal_connect(decodebin,
         "pad-added",
         G_CALLBACK(callbackIncomingDecodebinStream),

--- a/tasks/WebRTCReceiveTask.cpp
+++ b/tasks/WebRTCReceiveTask.cpp
@@ -222,7 +222,6 @@ void WebRTCReceiveTask::onIncomingStream(GstElement* webrtcbin, GstPad* pad)
     gst_bin_add(GST_BIN(m_pipeline), bin);
 
     GstElement* decodebin = gst_element_factory_make("decodebin", NULL);
-    g_object_set(decodebin, "max-size-buffers", 1, NULL);
     g_signal_connect(decodebin,
         "pad-added",
         G_CALLBACK(callbackIncomingDecodebinStream),

--- a/tasks/WebRTCReceiveTask.cpp
+++ b/tasks/WebRTCReceiveTask.cpp
@@ -164,18 +164,16 @@ GstElement* WebRTCReceiveTask::createPipeline(string const& peer_id)
 
 void WebRTCReceiveTask::handleVideoStream(GstElement* bin, GstPad* pad)
 {
-    GstElement* q = gst_element_factory_make("queue", NULL);
     GstElement* conv = gst_element_factory_make("videoconvert", NULL);
     GstElement* sink = gst_element_factory_make("appsink", "video_out");
+    // The max buffers is set to 1, so it gets the first value and send
+    // it directly, so it disables the buffer behavior
     g_object_set(sink, "max-buffers", 1, NULL);
     g_object_set(sink, "drop", true, NULL);
 
-    // gst_bin_add_many(GST_BIN(bin), q, conv, sink, NULL);
     gst_bin_add_many(GST_BIN(bin), conv, sink, NULL);
-    // gst_element_sync_state_with_parent(q);
     gst_element_sync_state_with_parent(conv);
     gst_element_sync_state_with_parent(sink);
-    // gst_element_link_many(q, conv, sink, NULL);
     gst_element_link_many(conv, sink, NULL);
     configureOutput(bin, "video_out", _frame_mode.get(), false, _video_out);
 
@@ -222,7 +220,6 @@ void WebRTCReceiveTask::onIncomingStream(GstElement* webrtcbin, GstPad* pad)
     gst_bin_add(GST_BIN(m_pipeline), bin);
 
     GstElement* decodebin = gst_element_factory_make("decodebin", NULL);
-    g_object_set(decodebin, "max-size-buffers", 1, NULL);
     g_signal_connect(decodebin,
         "pad-added",
         G_CALLBACK(callbackIncomingDecodebinStream),

--- a/tasks/WebRTCReceiveTask.cpp
+++ b/tasks/WebRTCReceiveTask.cpp
@@ -167,6 +167,8 @@ void WebRTCReceiveTask::handleVideoStream(GstElement* bin, GstPad* pad)
     GstElement* q = gst_element_factory_make("queue", NULL);
     GstElement* conv = gst_element_factory_make("videoconvert", NULL);
     GstElement* sink = gst_element_factory_make("appsink", "video_out");
+    // The max buffers is set to 1, so it gets the first value and send
+    // it directly, so it disables the buffer behavior
     g_object_set(sink, "max-buffers", 1, NULL);
     g_object_set(sink, "drop", true, NULL);
 


### PR DESCRIPTION
This was done during our ROV docking operation, the 07/06/2023. Initially we were having 600ms delay on the video feed. We reduced the latency of the jitterbuffer (initially at 200ms). We observed a drop of the delay to around 420ms. We also put the botamos o webrtcbin to drop on latency, so it can match the jitterbuffer latency.