### PR TITLE
fix: memory leaks

### DIFF
--- a/tasks/Helpers.hpp
+++ b/tasks/Helpers.hpp
@@ -36,6 +36,22 @@ namespace gstreamer {
             , unref(unref)
         {
         }
+
+        GstUnrefGuard(GstUnrefGuard&& other)
+        {
+            this->object = other.release();
+            this->unref = other.unref;
+        }
+
+        GstUnrefGuard(GstUnrefGuard const&) = delete;
+        GstUnrefGuard& operator=(GstUnrefGuard const&) = delete;
+
+        GstUnrefGuard& operator=(GstUnrefGuard&& other) {
+            this->object = other.release();
+            this->unref = other.unref;
+            return *this;
+        }
+
         ~GstUnrefGuard()
         {
             if (object) {
@@ -139,8 +155,7 @@ namespace gstreamer {
 
     inline GstCaps* jpegModeToGSTCaps(base::samples::frame::frame_mode_t frame_mode)
     {
-        GstCaps* caps =
-            gst_caps_new_empty_simple("image/jpeg");
+        GstCaps* caps = gst_caps_new_empty_simple("image/jpeg");
         if (!caps) {
             throw std::runtime_error("failed to generate caps");
         }

--- a/tasks/RTPTask.cpp
+++ b/tasks/RTPTask.cpp
@@ -72,21 +72,27 @@ bool RTPTask::configureHook()
         return false;
 
     m_rtp_monitoring_config = _rtp_monitoring_config.get();
-    m_bin = gst_bin_get_by_name(GST_BIN(m_pipeline),
-        m_rtp_monitoring_config.rtpbin_name.c_str());
-    if (!m_bin) {
+    GstUnrefGuard<GstElement> bin(gst_bin_get_by_name(GST_BIN(m_pipeline),
+        m_rtp_monitoring_config.rtpbin_name.c_str()));
+    if (!bin.get()) {
         throw std::runtime_error("cannot find element named " +
                                  m_rtp_monitoring_config.rtpbin_name + " in pipeline");
     }
 
-    // Free previous session variables.
-    // This cannot be done on stop hook since it
-    // will make tasks die unexpectedly on process server
-    for (auto const& internal_session : m_rtp_sessions) {
-        g_free(internal_session);
+    std::vector<GstUnrefGuard<GstElement>> sessions;
+    sessions.reserve(m_rtp_monitoring_config.sessions_id.size());
+    for (uint32_t session_id : m_rtp_monitoring_config.sessions_id) {
+        GstElement* session{nullptr};
+        g_signal_emit_by_name(bin.get(), "get-session", session_id, &session);
+        if (!session) {
+            throw std::runtime_error(
+                "did not resolve provided session, wrong session ID " +
+                to_string(session_id) + " ?");
+        }
+        sessions.emplace_back(session);
     }
-    // "Clear" m_rtp_sessions
-    m_rtp_sessions.clear();
+
+    m_rtp_sessions = std::move(sessions);
 
     return true;
 }
@@ -96,22 +102,6 @@ bool RTPTask::startHook()
     if (!RTPTaskBase::startHook())
         return false;
 
-    std::vector<GstElement*> sessions;
-    for (uint32_t session_id : m_rtp_monitoring_config.sessions_id) {
-        GstElement* session = nullptr;
-        g_signal_emit_by_name(m_bin,
-            "get-session",
-            session_id,
-            &session);
-        if (!session) {
-            throw std::runtime_error(
-                "did not resolve provided session, wrong session ID " +
-                to_string(session_id) + " ?");
-        }
-        sessions.push_back(session);
-    }
-
-    m_rtp_sessions = sessions;
     return true;
 }
 
@@ -120,9 +110,10 @@ void RTPTask::updateHook()
     RTPTaskBase::updateHook();
 
     RTPStatistics stats;
+    stats.statistics.reserve(m_rtp_sessions.size());
     stats.time = base::Time::now();
-    for (auto const& element : m_rtp_sessions) {
-        stats.statistics.push_back(updateRTPSessionStats(element));
+    for (auto& element : m_rtp_sessions) {
+        stats.statistics.push_back(updateRTPSessionStats(element.get()));
     }
     _rtp_statistics.write(stats);
 }
@@ -138,4 +129,5 @@ void RTPTask::stopHook()
 void RTPTask::cleanupHook()
 {
     RTPTaskBase::cleanupHook();
+    m_rtp_sessions.clear();
 }

--- a/tasks/RTPTask.hpp
+++ b/tasks/RTPTask.hpp
@@ -1,7 +1,7 @@
 #ifndef GSTREAMER_RTPTASK_TASK_HPP
 #define GSTREAMER_RTPTASK_TASK_HPP
 
-#include "gst/rtp/rtp.h"
+#include "Helpers.hpp"
 #include "gstreamer/RTPTaskBase.hpp"
 #include <base/Float.hpp>
 
@@ -52,10 +52,8 @@ namespace gstreamer {
 
         /** RTP Monitored Settings */
         RTPMonitoringConfig m_rtp_monitoring_config;
-        /** RTP bin element */
-        GstElement* m_bin;
         /** RTP sessions element */
-        std::vector<GstElement*> m_rtp_sessions;
+        std::vector<GstUnrefGuard<GstElement>> m_rtp_sessions;
 
         /**
          * Hook called when the state machine transitions from PreOperational to

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 rock_gtest(test_suite suite.cpp
             test_RTPHelpers.cpp
+            test_Helpers.cpp
     SOURCES ../tasks/RTPHelpers.cpp
     HEADERS ../tasks/RTPHelpers.hpp
     DEPS_PKGCONFIG gstreamer-1.0

--- a/test/rtp_task_test.rb
+++ b/test/rtp_task_test.rb
@@ -22,6 +22,14 @@ describe OroGen.gstreamer.RTPTask do
         end
     end
 
+    it "does not raise on re-configuration cycle" do
+        m = rtp_sender_m(@rtp_port)
+        sender = syskit_deploy_configure_and_start(m)
+        sender.needs_reconfiguration!
+        syskit_stop(sender)
+        syskit_deploy_configure_and_start(m)
+    end
+
     def rtp_sender_m(port)
         OroGen.gstreamer.RTPTask
               .with_arguments(

--- a/test/test_Helpers.cpp
+++ b/test/test_Helpers.cpp
@@ -1,0 +1,41 @@
+#include "../tasks/Helpers.hpp"
+#include <gtest/gtest.h>
+
+using namespace gstreamer;
+using namespace base;
+using namespace std;
+
+struct HelpersTest : public ::testing::Test {
+    HelpersTest()
+    {
+    }
+
+    inline static bool unreferred{false};
+    static void unref(GstElement* e)
+    {
+        unreferred = true;
+    }
+};
+
+TEST_F(HelpersTest, it_implements_move_constructor)
+{
+    GstElement obj;
+    GstUnrefGuard<GstElement> first_guard(&obj, unref);
+    GstUnrefGuard<GstElement> second_guard(std::move(first_guard));
+    ASSERT_EQ(nullptr, first_guard.get());
+    ASSERT_EQ(&obj, second_guard.get());
+}
+
+TEST_F(HelpersTest, it_implements_move_assignment)
+{
+    GstElement obj;
+    GstUnrefGuard<GstElement> second_guard(nullptr);
+    unreferred = false;
+    {
+        GstUnrefGuard<GstElement> first_guard(&obj, unref);
+        second_guard = std::move(first_guard);
+        ASSERT_EQ(nullptr, first_guard.get());
+    }
+    ASSERT_EQ(&obj, second_guard.get());
+    ASSERT_EQ(false, unreferred);
+}


### PR DESCRIPTION
- the bin element should be unrefered, the gst_bin_get_by_name is transfer:full
- calling g_free on the rtp sessions leads to _invalid pointer_. It also needs to be
unrefered, leaving memory management to
glib
