### PR TITLE
feat: rtp retransmission

### DIFF
--- a/gstreamer.orogen
+++ b/gstreamer.orogen
@@ -14,6 +14,7 @@ import_types_from "base"
 import_types_from "webrtc_base"
 import_types_from "iodrivers_base"
 import_types_from "tasks/RTPHelpers.hpp"
+import_types_from "gstreamer/rtpbin/receiver.hpp"
 
 OroGen::Spec::Deployment.register_global_initializer(:gstreamer)
 if defined?(OroGen::Gen::RTT_CPP::Deployment)
@@ -75,6 +76,10 @@ end
 task_context "RTPTask", subclasses: "Task" do
     # The RTPBIN element name and session ids
     property "rtp_monitoring_config", "/gstreamer/RTPMonitoringConfig"
+
+    # maps pipeline element names to rtp receiver roles
+    property "receiver_map", "/gstreamer/rtpbin/receiver/PipelineMapping"
+
     # Statistics output port
     output_port "rtp_statistics", "/gstreamer/RTPStatistics"
 

--- a/tasks/Common.cpp
+++ b/tasks/Common.cpp
@@ -49,7 +49,7 @@ bool Common::startHook()
 
     if (m_pipeline) {
         // log pipeline dot file after all specializations configureHook
-        gst_debug_bin_to_dot_file(GST_BIN(m_pipeline.get()),
+        gst_debug_bin_to_dot_file(m_pipeline.get(),
             GST_DEBUG_GRAPH_SHOW_VERBOSE,
             pipelineDotFileName().c_str());
     }
@@ -74,7 +74,7 @@ void Common::updateHook()
     if (!m_logged_playing_pipeline) {
         m_logged_playing_pipeline = true;
         // log pipeline dot file after all specializations configureHook
-        gst_debug_bin_to_dot_file(GST_BIN(m_pipeline.get()),
+        gst_debug_bin_to_dot_file(m_pipeline.get(),
             GST_DEBUG_GRAPH_SHOW_VERBOSE,
             pipelineDotFileName().c_str());
     }

--- a/tasks/Common.hpp
+++ b/tasks/Common.hpp
@@ -88,7 +88,7 @@ namespace gstreamer {
         std::list<ConfiguredInput> m_configured_inputs;
         std::list<ConfiguredOutput> m_configured_outputs;
 
-        std::shared_ptr<GstElement> m_pipeline;
+        std::shared_ptr<GstBin> m_pipeline;
 
         void configureOutput(GstElement* pipeline,
             std::string const& appsink_name,

--- a/tasks/RTPTask.cpp
+++ b/tasks/RTPTask.cpp
@@ -73,11 +73,12 @@ bool RTPTask::configureHook()
         return false;
 
     m_rtp_monitoring_config = _rtp_monitoring_config.get();
-    GstUnrefGuard<GstElement> bin(gst_bin_get_by_name(GST_BIN(m_pipeline.get()),
-        m_rtp_monitoring_config.rtpbin_name.c_str()));
+    std::string& rtpbin_name{m_rtp_monitoring_config.rtpbin_name};
+    GstUnrefGuard<GstElement> bin(
+        gst_bin_get_by_name(m_pipeline.get(), rtpbin_name.c_str()));
     if (!bin.get()) {
-        throw std::runtime_error("cannot find element named " +
-                                 m_rtp_monitoring_config.rtpbin_name + " in pipeline");
+        throw std::runtime_error(
+            "cannot find element named " + rtpbin_name + " in pipeline");
     }
 
     std::vector<GstUnrefGuard<GstElement>> sessions;

--- a/tasks/RTPTask.cpp
+++ b/tasks/RTPTask.cpp
@@ -11,6 +11,7 @@
 using namespace std;
 using namespace gstreamer;
 using namespace gstreamer::memory;
+using namespace gstreamer::rtpbin;
 using namespace base::samples::frame;
 
 RTPTask::RTPTask(std::string const& name)
@@ -81,6 +82,13 @@ bool RTPTask::configureHook()
             "cannot find element named " + rtpbin_name + " in pipeline");
     }
 
+    auto receiver_mapping = _receiver_map.get();
+    if (!receiver_mapping.undefined()) {
+        receiver::Context ctx = {m_pipeline, receiver_mapping};
+        m_receiver_context = ctx;
+        receiver::setup(rtpbin_name, *m_receiver_context);
+    }
+
     std::vector<GstUnrefGuard<GstElement>> sessions;
     sessions.reserve(m_rtp_monitoring_config.sessions_id.size());
     for (uint32_t session_id : m_rtp_monitoring_config.sessions_id) {
@@ -131,5 +139,6 @@ void RTPTask::stopHook()
 void RTPTask::cleanupHook()
 {
     RTPTaskBase::cleanupHook();
+    m_receiver_context = std::nullopt;
     m_rtp_sessions.clear();
 }

--- a/tasks/RTPTask.hpp
+++ b/tasks/RTPTask.hpp
@@ -1,10 +1,12 @@
 #ifndef GSTREAMER_RTPTASK_TASK_HPP
 #define GSTREAMER_RTPTASK_TASK_HPP
 
+#include <base/Float.hpp>
+
 #include "Helpers.hpp"
 #include "gstreamer/RTPTaskBase.hpp"
-#include <base/Float.hpp>
 #include <gstreamer/memory.hpp>
+#include <gstreamer/rtpbin/receiver.hpp>
 
 namespace gstreamer {
     /*! \class RTPTask
@@ -27,6 +29,9 @@ namespace gstreamer {
      */
     class RTPTask : public RTPTaskBase {
         friend class RTPTaskBase;
+
+    protected:
+        std::optional<rtpbin::receiver::Context> m_receiver_context;
 
     public:
         /** TaskContext constructor for Task

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -55,8 +55,8 @@ bool Task::configureHook()
 
     configureRawIO(*pipeline);
 
-    m_pipeline =
-        std::shared_ptr<GstElement>(unref_guard.release(), memory::PipelineDestructor());
+    m_pipeline = std::shared_ptr<GstBin>(GST_BIN(unref_guard.release()),
+        memory::PipelineDestructor());
     return true;
 }
 

--- a/tasks/WebRTCReceiveTask.cpp
+++ b/tasks/WebRTCReceiveTask.cpp
@@ -35,7 +35,7 @@ bool WebRTCReceiveTask::configureHook()
 
     auto config = _signalling.get();
     if (!config.polite && !config.remote_peer_id.empty()) {
-        m_pipeline = std::shared_ptr<GstElement>(createPipeline(config.remote_peer_id),
+        m_pipeline = std::shared_ptr<GstBin>(createPipeline(config.remote_peer_id),
             memory::PipelineDestructor());
     }
     m_decode_queue_max_size_time = _decode_queue_max_size_time.get();
@@ -79,7 +79,7 @@ void WebRTCReceiveTask::processSignallingMessage(SignallingMessage const& messag
         if (m_pipeline) {
             destroyPipeline();
         }
-        m_pipeline = std::shared_ptr<GstElement>(createPipeline(message.from),
+        m_pipeline = std::shared_ptr<GstBin>(createPipeline(message.from),
             memory::PipelineDestructor());
         startPipeline();
         return;
@@ -94,7 +94,7 @@ void WebRTCReceiveTask::processSignallingMessage(SignallingMessage const& messag
         if (m_pipeline) {
             destroyPipeline();
         }
-        m_pipeline = std::shared_ptr<GstElement>(createPipeline(message.from),
+        m_pipeline = std::shared_ptr<GstBin>(createPipeline(message.from),
             memory::PipelineDestructor());
         startPipeline();
     }
@@ -149,7 +149,7 @@ string WebRTCReceiveTask::getCurrentPeer() const
 
     return m_peers.begin()->second.peer_id;
 }
-GstElement* WebRTCReceiveTask::createPipeline(string const& peer_id)
+GstBin* WebRTCReceiveTask::createPipeline(string const& peer_id)
 {
     GstUnrefGuard<GstElement> pipe(gst_pipeline_new("receivepipe"));
     GstElement* webrtc = gst_element_factory_make("webrtcbin", "webrtc");
@@ -163,7 +163,7 @@ GstElement* WebRTCReceiveTask::createPipeline(string const& peer_id)
 
     LOG_INFO_S << "Created pipeline " << hasPeer(peer_id);
 
-    return pipe.release();
+    return GST_BIN(pipe.release());
 
     // TODO: look into TWCC
 }
@@ -223,7 +223,7 @@ void WebRTCReceiveTask::onIncomingStream(GstElement* webrtcbin, GstPad* pad)
 
     auto const& peer = m_peers[webrtcbin];
     GstElement* bin = gst_bin_new((peer.peer_id + "_receivebin").c_str());
-    gst_bin_add(GST_BIN(m_pipeline.get()), bin);
+    gst_bin_add(m_pipeline.get(), bin);
 
     GstElement* q = gst_element_factory_make("queue", NULL);
     GstElement* decodebin = gst_element_factory_make("decodebin", NULL);

--- a/tasks/WebRTCReceiveTask.hpp
+++ b/tasks/WebRTCReceiveTask.hpp
@@ -36,7 +36,7 @@ namespace gstreamer {
         void updatePeersStats() override;
 
         std::string getCurrentPeer() const;
-        GstElement* createPipeline(std::string const& peer_id = "");
+        GstBin* createPipeline(std::string const& peer_id = "");
 
         static void callbackIncomingStream(GstElement* webrtcbin,
             GstPad* pad,

--- a/tasks/WebRTCSendTask.cpp
+++ b/tasks/WebRTCSendTask.cpp
@@ -35,7 +35,7 @@ bool WebRTCSendTask::configureHook()
     }
 
     m_pipeline =
-        std::shared_ptr<GstElement>(createPipeline(), memory::PipelineDestructor());
+        std::shared_ptr<GstBin>(createPipeline(), memory::PipelineDestructor());
     return true;
 }
 bool WebRTCSendTask::startHook()
@@ -116,7 +116,7 @@ void WebRTCSendTask::stopHook()
     }
 
     WebRTCSendTaskBase::stopHook();
-    gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
+    gst_element_set_state(GST_ELEMENT(m_pipeline.get()), GST_STATE_PAUSED);
 }
 
 void WebRTCSendTask::cleanupHook()
@@ -125,7 +125,7 @@ void WebRTCSendTask::cleanupHook()
     WebRTCSendTaskBase::cleanupHook();
 }
 
-GstElement* WebRTCSendTask::createPipeline()
+GstBin* WebRTCSendTask::createPipeline()
 {
     string pipeline_definition = "appsrc format=3 do-timestamp=TRUE "
                                  "is-live=true name=src !" +
@@ -141,7 +141,7 @@ GstElement* WebRTCSendTask::createPipeline()
     }
 
     configureInput(pipeline, "src", false, _video_in);
-    return pipeline;
+    return GST_BIN(pipeline);
 }
 
 void WebRTCSendTask::configurePeer(string const& peer_id)
@@ -154,10 +154,10 @@ void WebRTCSendTask::configurePeer(string const& peer_id)
     GstUnrefGuard<GstPad> queue_sink(gst_element_get_static_pad(queue, "sink"));
     auto pad = gst_ghost_pad_new("sink", queue_sink.get());
     gst_element_add_pad(bin, pad);
-    gst_bin_add(GST_BIN(m_pipeline.get()), bin);
+    gst_bin_add(m_pipeline.get(), bin);
 
     GstUnrefGuard<GstElement> splitter(
-        gst_bin_get_by_name(GST_BIN(m_pipeline.get()), "splitter"));
+        gst_bin_get_by_name(m_pipeline.get(), "splitter"));
 #if GST_CHECK_VERSION(1, 20, 0)
     GstUnrefGuard<GstPad> srcpad(
         gst_element_request_pad_simple(splitter.get(), "src_%u"));
@@ -200,9 +200,9 @@ void WebRTCSendTask::disconnectPeer(PeerMap::iterator peer_it)
 
     gst_element_set_state(elements.bin, GST_STATE_NULL);
     GstUnrefGuard<GstElement> splitter(
-        gst_bin_get_by_name(GST_BIN(m_pipeline.get()), "splitter"));
+        gst_bin_get_by_name(m_pipeline.get(), "splitter"));
     gst_element_unlink_many(splitter.get(), elements.bin, nullptr);
-    gst_bin_remove_many(GST_BIN(m_pipeline.get()), elements.bin, nullptr);
+    gst_bin_remove_many(m_pipeline.get(), elements.bin, nullptr);
 
     gst_element_release_request_pad(splitter.get(), elements.tee_pad);
 }

--- a/tasks/WebRTCSendTask.hpp
+++ b/tasks/WebRTCSendTask.hpp
@@ -29,7 +29,7 @@ namespace gstreamer {
         friend class WebRTCSendTaskBase;
 
     protected:
-        GstElement* createPipeline();
+        GstBin* createPipeline();
         void disconnectPeer(PeerMap::iterator peer_it);
         void configurePeer(std::string const& peer_id);
         void destroyPipeline() override;

--- a/test/rtp_task_test.rb
+++ b/test/rtp_task_test.rb
@@ -30,6 +30,70 @@ describe OroGen.gstreamer.RTPTask do
         syskit_deploy_configure_and_start(m)
     end
 
+    describe "retransmission" do
+        attr_reader :ports
+        before do
+            @ports = 6.times.map { |_| allocate_available_port }
+        end
+
+        it "can setup rtpbin as receiver with receiver::PipelineMapping" do
+            receiver_m =
+                OroGen.gstreamer.RTPTask
+                .with_arguments(
+                    pipeline: <<~PIPELINE
+                        rtpbin name=receive rtp-profile=avpf latency=250 do-retransmission=true
+                               fec-decoders=fec,0="rtpst2022-1-fecdec\\ size-time\\=1000000000";
+                        udpsrc name="rtp_src" port=#{ports[0]}
+                               caps="application/x-rtp,media=(string)video,clock-rate=(int)90000,
+                               encoding-name=(string)H264,payload=(int)96"
+                        queue name="rtp_sink"
+                        ! udpsink host=127.0.0.1 port=#{ports[5]}
+                        udpsrc name="rtcp_src" port=#{ports[1]}
+                        udpsink name="rtcp_feedback_sink" host=127.0.0.1 port=#{ports[2]}
+                        udpsrc name="row_fec" port=#{ports[3]}
+                        udpsrc name="col_fec" port=#{ports[4]}
+                    PIPELINE
+                )
+                .with_arguments(rtp_monitoring_config:
+                    { rtpbin_name: "receive", sessions_id: [0] })
+                .deployed_as("rtpreceive")
+
+            transmit_m =
+                OroGen.gstreamer.RTPTask
+                .with_arguments(
+                    pipeline: <<~PIPELINE
+                        rtpbin name=transmit rtp-profile=avpf
+                        videotestsrc
+                        ! x264enc speed-preset=ultrafast
+                        ! rtph264pay ssrc=0 aggregate-mode=zero-latency config-interval=-1
+                        ! application/x-rtp,media=video,clock-rate=90000,encoding-name=H264,payload=96
+                        ! transmit.send_rtp_sink_0
+                        transmit.send_rtp_src_0
+                        ! udpsink host=127.0.0.1 port=#{ports[0]}
+                        transmit.send_rtcp_src_0
+                        ! udpsink host=127.0.0.1 port=#{ports[1]} sync=false async=false
+                        udpsrc port=#{ports[2]}
+                        ! transmit.recv_rtcp_sink_0
+                    PIPELINE
+                )
+                .with_arguments(rtp_monitoring_config:
+                    { rtpbin_name: "transmit", sessions_id: [0] })
+                .deployed_as("rtptransmit")
+
+            syskit_deploy_configure_and_start(transmit_m)
+
+            receiver_t = syskit_deploy(receiver_m)
+            receiver_t.property_overrides.receiver_map =
+                { session_id: 0, rtp_source: "rtp_src",
+                  rtp_sink: "rtp_sink", rtcp_source: "rtcp_src",
+                  rtcp_feedback_sink: "rtcp_feedback_sink",
+                  fec_source_0: "row_fec", fec_source_1: "col_fec" }
+            receiver_t.needs_reconfiguration!
+
+            syskit_configure_and_start(receiver_t)
+        end
+    end
+
     def rtp_sender_m(port)
         OroGen.gstreamer.RTPTask
               .with_arguments(


### PR DESCRIPTION
On top of:
- [ ] https://github.com/tidewise/drivers-orogen-gstreamer/pull/24

Depends on:
- [ ] https://github.com/tidewise/drivers-gstreamer/pull/3


review tip: the real work is done just at [feat: support fec and retransmission simultaneously](https://github.com/tidewise/drivers-orogen-gstreamer/commit/d2fe544a4c703fd5e01b3116ec94d7eeb67300a2)
### What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Add support for having both retransmission and fec simultaneously on the receiver pipeline. 


